### PR TITLE
🐛 Close file descriptor when flock fails

### DIFF
--- a/src/unix.rs
+++ b/src/unix.rs
@@ -26,11 +26,13 @@ impl FileLock {
             if fd < 0 {
                 return Err(errno::errno());
             }
-            self.fd = fd;
 
             if libc::flock(fd, libc::LOCK_EX) != 0 {
-                return Err(errno::errno());
+                let lock_error = errno::errno();
+                libc::close(fd);
+                return Err(lock_error);
             }
+            self.fd = fd;
             Ok(FileLockGuard::new(self))
         }
     }


### PR DESCRIPTION
Close the Unix file descriptor immediately when `flock` fails while preserving the original locking error. This prevents descriptors from leaking across repeated lock attempts.