### PR TITLE
🐛 Return an error for paths containing NUL

### DIFF
--- a/src/unix.rs
+++ b/src/unix.rs
@@ -21,7 +21,8 @@ impl FileLock {
 
     pub fn lock(&mut self) -> Result<FileLockGuard<'_>, errno::Errno> {
         unsafe {
-            let c_filename = CString::new(self.filename.as_os_str().as_bytes()).unwrap();
+            let c_filename = CString::new(self.filename.as_os_str().as_bytes())
+                .map_err(|_| errno::Errno(libc::EINVAL))?;
             let fd = libc::open(c_filename.as_ptr(), libc::O_RDWR | libc::O_CREAT, 0o644);
             if fd < 0 {
                 return Err(errno::errno());

--- a/tests/error.rs
+++ b/tests/error.rs
@@ -9,6 +9,18 @@ fn test_invalid_path_locking() {
 
 #[cfg(unix)]
 #[test]
+fn test_path_with_interior_nul_returns_error() {
+    use std::ffi::OsStr;
+    use std::os::unix::ffi::OsStrExt;
+
+    let mut lock = FileLock::new(OsStr::from_bytes(b"invalid\0path.lock"));
+    let result = lock.lock();
+
+    assert_eq!(result.err(), Some(errno::Errno(libc::EINVAL)));
+}
+
+#[cfg(unix)]
+#[test]
 fn test_file_permission_denied() {
     use std::fs::File;
     use std::os::unix::fs::PermissionsExt;


### PR DESCRIPTION
Return `EINVAL` instead of panicking when a Unix lock path contains an interior NUL byte. Add a regression test covering the invalid path.