### PR TITLE
🔒 Restrict file lock guard construction

### DIFF
--- a/src/guard.rs
+++ b/src/guard.rs
@@ -11,7 +11,7 @@ pub struct FileLockGuard<'a> {
 }
 
 impl<'a> FileLockGuard<'a> {
-    pub fn new(lock: &'a mut FileLock) -> Self {
+    pub(crate) fn new(lock: &'a mut FileLock) -> Self {
         FileLockGuard {
             lock,
             unlocked: false,


### PR DESCRIPTION
Make `FileLockGuard::new` crate-private so callers can only obtain a guard after successfully acquiring a lock. This preserves the guard construction invariant without changing the public locking API.