### PR TITLE
✨ Add non-blocking try_lock support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["filesystem", "concurrency"]
 errno = "^0.3"
 
 [target.'cfg(windows)'.dependencies]
-winapi = { version = "^0.3", features = ["handleapi", "fileapi"] }
+winapi = { version = "^0.3", features = ["handleapi", "fileapi", "winerror"] }
 
 [target.'cfg(unix)'.dependencies]
 libc = "^0.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,18 @@
 //!     Ok(())
 //! }
 //! ```
+
+//! To attempt locking without waiting:
+//!
+//! ```rust
+//! let mut lock = filelock::new("myfile.lock");
+//! if let Some(_guard) = lock.try_lock()? {
+//!     // The lock was acquired.
+//! } else {
+//!     // The lock is currently held elsewhere.
+//! }
+//! # Ok::<(), errno::Errno>(())
+//! ```
 //!
 //! For manual control:
 //!

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -38,6 +38,33 @@ impl FileLock {
         }
     }
 
+    /// Attempts to acquire the lock without blocking.
+    ///
+    /// Returns `Ok(None)` when another process or thread currently holds the
+    /// lock, and `Ok(Some(_))` when the lock was acquired.
+    pub fn try_lock(&mut self) -> Result<Option<FileLockGuard<'_>>, errno::Errno> {
+        unsafe {
+            let c_filename = CString::new(self.filename.as_os_str().as_bytes())
+                .map_err(|_| errno::Errno(libc::EINVAL))?;
+            let fd = libc::open(c_filename.as_ptr(), libc::O_RDWR | libc::O_CREAT, 0o644);
+            if fd < 0 {
+                return Err(errno::errno());
+            }
+
+            if libc::flock(fd, libc::LOCK_EX | libc::LOCK_NB) != 0 {
+                let lock_error = errno::errno();
+                libc::close(fd);
+                if lock_error.0 == libc::EWOULDBLOCK || lock_error.0 == libc::EAGAIN {
+                    return Ok(None);
+                }
+                return Err(lock_error);
+            }
+
+            self.fd = fd;
+            Ok(Some(FileLockGuard::new(self)))
+        }
+    }
+
     pub(crate) fn unlock(&mut self) -> Result<(), errno::Errno> {
         let fd = self.fd;
         if fd < 0 {

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -70,6 +70,39 @@ impl FileLock {
         return Ok(FileLockGuard::new(self));
     }
 
+    /// Attempts to acquire the lock without blocking.
+    ///
+    /// Returns `Ok(None)` when another process or thread currently holds the
+    /// lock, and `Ok(Some(_))` when the lock was acquired.
+    pub fn try_lock(&mut self) -> Result<Option<FileLockGuard<'_>>, errno::Errno> {
+        if self.handle == winapi::um::handleapi::INVALID_HANDLE_VALUE {
+            return Err(self.create_error.unwrap_or(errno::errno()));
+        }
+
+        unsafe {
+            let mut overlapped: winapi::um::minwinbase::OVERLAPPED = winapi::_core::mem::zeroed();
+            let locked = winapi::um::fileapi::LockFileEx(
+                self.handle,
+                winapi::um::minwinbase::LOCKFILE_EXCLUSIVE_LOCK
+                    | winapi::um::minwinbase::LOCKFILE_FAIL_IMMEDIATELY,
+                0,
+                !0,
+                !0,
+                &mut overlapped,
+            );
+
+            if locked != winapi::shared::minwindef::TRUE {
+                let lock_error = errno::errno();
+                if lock_error.0 == winapi::shared::winerror::ERROR_LOCK_VIOLATION as i32 {
+                    return Ok(None);
+                }
+                return Err(lock_error);
+            }
+        }
+
+        Ok(Some(FileLockGuard::new(self)))
+    }
+
     pub(crate) fn unlock(&mut self) -> Result<(), errno::Errno> {
         unsafe {
             let mut overlapped: winapi::um::minwinbase::OVERLAPPED = winapi::_core::mem::zeroed();

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -29,6 +29,15 @@ fn test_raii_automatic_unlock() {
 }
 
 #[test]
+fn test_try_lock_when_available() {
+    let filename = "test_try_available.lock";
+    let mut lock = FileLock::new(filename);
+
+    let guard = lock.try_lock().unwrap();
+    assert!(guard.is_some());
+}
+
+#[test]
 fn test_multiple_instances_same_file() {
     let filename = "test_instances.lock";
     let mut lock1 = FileLock::new(filename);

--- a/tests/concurrent.rs
+++ b/tests/concurrent.rs
@@ -124,3 +124,31 @@ fn test_lock_timeout_behavior() {
     holder_handle.join().unwrap();
     waiter_handle.join().unwrap();
 }
+
+#[test]
+fn test_try_lock_returns_immediately_when_held() {
+    let filename = "test_try_contended.lock";
+    let holder_started = Arc::new(Barrier::new(2));
+    let release_holder = Arc::new(Barrier::new(2));
+
+    let holder_started_clone = holder_started.clone();
+    let release_holder_clone = release_holder.clone();
+    let holder = thread::spawn(move || {
+        let mut lock = FileLock::new(filename);
+        let _guard = lock.lock().unwrap();
+        holder_started_clone.wait();
+        release_holder_clone.wait();
+    });
+
+    holder_started.wait();
+    let mut contender = FileLock::new(filename);
+    let start = Instant::now();
+    let result = contender.try_lock().unwrap();
+    assert!(result.is_none());
+    assert!(start.elapsed() < Duration::from_secs(1));
+    drop(result);
+
+    release_holder.wait();
+    holder.join().unwrap();
+    assert!(contender.try_lock().unwrap().is_some());
+}


### PR DESCRIPTION
Adds a cross-platform try_lock API that returns immediately when a lock is unavailable. Includes coverage for successful and contended lock attempts.