### PR TITLE
♻️ Redesign cross-platform error handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,9 +10,6 @@ readme = "README.md"
 keywords = ["file", "lock", "flock", "locking", "mutex"]
 categories = ["filesystem", "concurrency"]
 
-[dependencies]
-errno = "^0.3"
-
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "^0.3", features = ["handleapi", "fileapi", "winerror"] }
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,18 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 ```
 
+Errors are reported as `filelock::Error`. The error identifies which operation failed and exposes both a portable `std::io::ErrorKind` and, when available, the platform-specific error code:
+
+```rust
+use filelock::{ErrorOperation, FileLock};
+
+let mut lock = FileLock::new("missing/directory/myfile.lock");
+if let Err(error) = lock.lock() {
+    assert_eq!(error.operation(), ErrorOperation::Open);
+    eprintln!("{} ({:?})", error, error.kind());
+}
+```
+
 ## Documentation
 
 See https://docs.rs/filelock/latest/filelock/.

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,80 @@
+use std::fmt;
+use std::io;
+
+/// The operation that failed while managing a file lock.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum ErrorOperation {
+    /// Opening or creating the lock file.
+    Open,
+    /// Acquiring the file lock.
+    Lock,
+    /// Releasing the file lock.
+    Unlock,
+    /// Closing the lock file after use.
+    Close,
+}
+
+impl fmt::Display for ErrorOperation {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Self::Open => "open lock file",
+            Self::Lock => "acquire file lock",
+            Self::Unlock => "release file lock",
+            Self::Close => "close lock file",
+        })
+    }
+}
+
+/// An error produced while opening, acquiring, or releasing a file lock.
+#[derive(Debug)]
+pub struct Error {
+    operation: ErrorOperation,
+    source: io::Error,
+}
+
+impl Error {
+    pub(crate) fn new(operation: ErrorOperation, source: io::Error) -> Self {
+        Self { operation, source }
+    }
+
+    /// Returns the operation that failed.
+    pub fn operation(&self) -> ErrorOperation {
+        self.operation
+    }
+
+    /// Returns the portable category of the underlying operating-system error.
+    pub fn kind(&self) -> io::ErrorKind {
+        self.source.kind()
+    }
+
+    /// Returns the operating-system error code, when one is available.
+    pub fn raw_os_error(&self) -> Option<i32> {
+        self.source.raw_os_error()
+    }
+
+    /// Returns the underlying I/O error.
+    pub fn io_error(&self) -> &io::Error {
+        &self.source
+    }
+
+    /// Consumes this error and returns the underlying I/O error.
+    pub fn into_io_error(self) -> io::Error {
+        self.source
+    }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "failed to {}: {}", self.operation, self.source)
+    }
+}
+
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(&self.source)
+    }
+}
+
+/// A result returned by file-locking operations.
+pub type Result<T> = std::result::Result<T, Error>;

--- a/src/guard.rs
+++ b/src/guard.rs
@@ -1,4 +1,4 @@
-use crate::FileLock;
+use crate::{FileLock, Result};
 
 /// A guard that holds a file lock and automatically releases it when dropped.
 ///
@@ -36,7 +36,7 @@ impl<'a> FileLockGuard<'a> {
     /// // Manually unlock with error handling
     /// guard.unlock().unwrap();
     /// ```
-    pub fn unlock(mut self) -> Result<(), errno::Errno> {
+    pub fn unlock(mut self) -> Result<()> {
         if !self.unlocked {
             self.lock.unlock()?;
             self.unlocked = true;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@
 //! } else {
 //!     // The lock is currently held elsewhere.
 //! }
-//! # Ok::<(), errno::Errno>(())
+//! # Ok::<(), filelock::Error>(())
 //! ```
 //!
 //! For manual control:
@@ -44,6 +44,9 @@
 
 mod guard;
 pub use guard::FileLockGuard;
+
+mod error;
+pub use error::{Error, ErrorOperation, Result};
 
 #[cfg(unix)]
 mod unix;

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -1,8 +1,8 @@
-extern crate errno;
 extern crate libc;
 
-use crate::FileLockGuard;
+use crate::{Error, ErrorOperation, FileLockGuard, Result};
 use std::ffi::CString;
+use std::io;
 use std::os::unix::ffi::OsStrExt;
 use std::path::{Path, PathBuf};
 
@@ -19,19 +19,23 @@ impl FileLock {
         }
     }
 
-    pub fn lock(&mut self) -> Result<FileLockGuard<'_>, errno::Errno> {
+    pub fn lock(&mut self) -> Result<FileLockGuard<'_>> {
         unsafe {
-            let c_filename = CString::new(self.filename.as_os_str().as_bytes())
-                .map_err(|_| errno::Errno(libc::EINVAL))?;
+            let c_filename = CString::new(self.filename.as_os_str().as_bytes()).map_err(|_| {
+                Error::new(
+                    ErrorOperation::Open,
+                    io::Error::from(io::ErrorKind::InvalidInput),
+                )
+            })?;
             let fd = libc::open(c_filename.as_ptr(), libc::O_RDWR | libc::O_CREAT, 0o644);
             if fd < 0 {
-                return Err(errno::errno());
+                return Err(Error::new(ErrorOperation::Open, io::Error::last_os_error()));
             }
 
             if libc::flock(fd, libc::LOCK_EX) != 0 {
-                let lock_error = errno::errno();
+                let lock_error = io::Error::last_os_error();
                 libc::close(fd);
-                return Err(lock_error);
+                return Err(Error::new(ErrorOperation::Lock, lock_error));
             }
             self.fd = fd;
             Ok(FileLockGuard::new(self))
@@ -42,22 +46,27 @@ impl FileLock {
     ///
     /// Returns `Ok(None)` when another process or thread currently holds the
     /// lock, and `Ok(Some(_))` when the lock was acquired.
-    pub fn try_lock(&mut self) -> Result<Option<FileLockGuard<'_>>, errno::Errno> {
+    pub fn try_lock(&mut self) -> Result<Option<FileLockGuard<'_>>> {
         unsafe {
-            let c_filename = CString::new(self.filename.as_os_str().as_bytes())
-                .map_err(|_| errno::Errno(libc::EINVAL))?;
+            let c_filename = CString::new(self.filename.as_os_str().as_bytes()).map_err(|_| {
+                Error::new(
+                    ErrorOperation::Open,
+                    io::Error::from(io::ErrorKind::InvalidInput),
+                )
+            })?;
             let fd = libc::open(c_filename.as_ptr(), libc::O_RDWR | libc::O_CREAT, 0o644);
             if fd < 0 {
-                return Err(errno::errno());
+                return Err(Error::new(ErrorOperation::Open, io::Error::last_os_error()));
             }
 
             if libc::flock(fd, libc::LOCK_EX | libc::LOCK_NB) != 0 {
-                let lock_error = errno::errno();
+                let lock_error = io::Error::last_os_error();
                 libc::close(fd);
-                if lock_error.0 == libc::EWOULDBLOCK || lock_error.0 == libc::EAGAIN {
+                if matches!(lock_error.raw_os_error(), Some(code) if code == libc::EWOULDBLOCK || code == libc::EAGAIN)
+                {
                     return Ok(None);
                 }
-                return Err(lock_error);
+                return Err(Error::new(ErrorOperation::Lock, lock_error));
             }
 
             self.fd = fd;
@@ -65,7 +74,7 @@ impl FileLock {
         }
     }
 
-    pub(crate) fn unlock(&mut self) -> Result<(), errno::Errno> {
+    pub(crate) fn unlock(&mut self) -> Result<()> {
         let fd = self.fd;
         if fd < 0 {
             return Ok(());
@@ -78,13 +87,16 @@ impl FileLock {
             // close() releases any flock held on the descriptor, so we always
             // close it and only then report the first error encountered.
             let unlock_failed = libc::flock(fd, libc::LOCK_UN) != 0;
-            let unlock_errno = errno::errno();
+            let unlock_error = io::Error::last_os_error();
 
             if libc::close(fd) != 0 {
-                return Err(errno::errno());
+                return Err(Error::new(
+                    ErrorOperation::Close,
+                    io::Error::last_os_error(),
+                ));
             }
             if unlock_failed {
-                return Err(unlock_errno);
+                return Err(Error::new(ErrorOperation::Unlock, unlock_error));
             }
         }
 

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -1,12 +1,13 @@
 extern crate winapi;
 
-use crate::FileLockGuard;
+use crate::{Error, ErrorOperation, FileLockGuard, Result};
+use std::io;
 use std::os::windows::ffi::OsStrExt;
 use std::path::Path;
 
 pub struct FileLock {
     handle: winapi::um::winnt::HANDLE,
-    create_error: Option<errno::Errno>,
+    create_error: Option<i32>,
 }
 
 impl FileLock {
@@ -32,9 +33,14 @@ impl FileLock {
             )
         };
 
-        // Save error if CreateFileW failed, to avoid errno race conditions
+        // Save GetLastError immediately if CreateFileW failed, before another
+        // Win32 call can overwrite the thread-local value.
         let create_error = if handle == winapi::um::handleapi::INVALID_HANDLE_VALUE {
-            Some(errno::errno())
+            Some(
+                io::Error::last_os_error()
+                    .raw_os_error()
+                    .unwrap_or(winapi::shared::winerror::ERROR_GEN_FAILURE as i32),
+            )
         } else {
             None
         };
@@ -45,10 +51,14 @@ impl FileLock {
         }
     }
 
-    pub fn lock(&mut self) -> Result<FileLockGuard<'_>, errno::Errno> {
+    pub fn lock(&mut self) -> Result<FileLockGuard<'_>> {
         // Check if file handle is valid from new()
         if self.handle == winapi::um::handleapi::INVALID_HANDLE_VALUE {
-            return Err(self.create_error.unwrap_or(errno::errno()));
+            let error = self
+                .create_error
+                .map(io::Error::from_raw_os_error)
+                .unwrap_or_else(io::Error::last_os_error);
+            return Err(Error::new(ErrorOperation::Open, error));
         }
 
         #[allow(dangling_pointers_from_temporaries)]
@@ -64,19 +74,23 @@ impl FileLock {
             );
 
             if locked != winapi::shared::minwindef::TRUE {
-                return Err(errno::errno());
+                return Err(Error::new(ErrorOperation::Lock, io::Error::last_os_error()));
             }
         }
-        return Ok(FileLockGuard::new(self));
+        Ok(FileLockGuard::new(self))
     }
 
     /// Attempts to acquire the lock without blocking.
     ///
     /// Returns `Ok(None)` when another process or thread currently holds the
     /// lock, and `Ok(Some(_))` when the lock was acquired.
-    pub fn try_lock(&mut self) -> Result<Option<FileLockGuard<'_>>, errno::Errno> {
+    pub fn try_lock(&mut self) -> Result<Option<FileLockGuard<'_>>> {
         if self.handle == winapi::um::handleapi::INVALID_HANDLE_VALUE {
-            return Err(self.create_error.unwrap_or(errno::errno()));
+            let error = self
+                .create_error
+                .map(io::Error::from_raw_os_error)
+                .unwrap_or_else(io::Error::last_os_error);
+            return Err(Error::new(ErrorOperation::Open, error));
         }
 
         unsafe {
@@ -92,18 +106,20 @@ impl FileLock {
             );
 
             if locked != winapi::shared::minwindef::TRUE {
-                let lock_error = errno::errno();
-                if lock_error.0 == winapi::shared::winerror::ERROR_LOCK_VIOLATION as i32 {
+                let lock_error = io::Error::last_os_error();
+                if lock_error.raw_os_error()
+                    == Some(winapi::shared::winerror::ERROR_LOCK_VIOLATION as i32)
+                {
                     return Ok(None);
                 }
-                return Err(lock_error);
+                return Err(Error::new(ErrorOperation::Lock, lock_error));
             }
         }
 
         Ok(Some(FileLockGuard::new(self)))
     }
 
-    pub(crate) fn unlock(&mut self) -> Result<(), errno::Errno> {
+    pub(crate) fn unlock(&mut self) -> Result<()> {
         unsafe {
             let mut overlapped: winapi::um::minwinbase::OVERLAPPED = winapi::_core::mem::zeroed();
             let unlocked = winapi::um::fileapi::UnlockFileEx(
@@ -115,13 +131,16 @@ impl FileLock {
             );
 
             if unlocked != winapi::shared::minwindef::TRUE {
-                return Err(errno::errno());
+                return Err(Error::new(
+                    ErrorOperation::Unlock,
+                    io::Error::last_os_error(),
+                ));
             }
 
             // Don't close handle here - it will be closed when FileLock is dropped
         }
 
-        return Ok(());
+        Ok(())
     }
 }
 

--- a/tests/error.rs
+++ b/tests/error.rs
@@ -1,10 +1,14 @@
-use filelock::FileLock;
+use filelock::{ErrorOperation, FileLock};
 
 #[test]
 fn test_invalid_path_locking() {
     let mut lock = FileLock::new("/invalid/path/that/does/not/exist/test.lock");
     let result = lock.lock();
     assert!(result.is_err(), "Locking on invalid path should fail");
+    let error = result.err().unwrap();
+    assert_eq!(error.operation(), ErrorOperation::Open);
+    assert!(std::error::Error::source(&error).is_some());
+    assert!(error.to_string().starts_with("failed to open lock file:"));
 }
 
 #[cfg(unix)]
@@ -16,7 +20,13 @@ fn test_path_with_interior_nul_returns_error() {
     let mut lock = FileLock::new(OsStr::from_bytes(b"invalid\0path.lock"));
     let result = lock.lock();
 
-    assert_eq!(result.err(), Some(errno::Errno(libc::EINVAL)));
+    let error = match result {
+        Err(error) => error,
+        Ok(_) => panic!("path containing NUL unexpectedly succeeded"),
+    };
+    assert_eq!(error.operation(), ErrorOperation::Open);
+    assert_eq!(error.kind(), std::io::ErrorKind::InvalidInput);
+    assert_eq!(error.raw_os_error(), None);
 }
 
 #[cfg(unix)]


### PR DESCRIPTION
Introduce a structured cross-platform error type that exposes the failed operation, portable I/O error kind, and underlying OS error. Replace the public errno dependency and use the correct Win32 last-error reporting path.